### PR TITLE
Add /lotto shift leave command

### DIFF
--- a/server/command/info.go
+++ b/server/command/info.go
@@ -41,7 +41,7 @@ func (c *Command) info(parameters []string) (string, error) {
 	- [x] fill: evaluates shift readiness, autofills.
 	- [x] finish: finishes a shift.
 	- [x] join: add user(s) to shift.
-	- [ ] leave: remove user(s) from shift.
+	- [x] leave: remove user(s) from shift.
 	- [x] list
 	- [ ] show
 	- [x] start: starts a shift.

--- a/server/command/shift.go
+++ b/server/command/shift.go
@@ -21,7 +21,7 @@ func (c *Command) shift(parameters []string) (string, error) {
 		commandList:        c.listShifts,
 		commandStart:       c.startShift,
 		commandFinish:      c.finishShift,
-		// commandLeave:       c.leaveShift,
+		commandLeave:       c.leaveShift,
 	}
 
 	return c.handleCommand(subcommands, parameters)

--- a/server/command/shift_leave.go
+++ b/server/command/shift_leave.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package command
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	sl "github.com/mattermost/mattermost-plugin-solar-lottery/server/solarlottery"
+)
+
+func (c *Command) leaveShift(parameters []string) (string, error) {
+	var usernames string
+	return c.doShift(parameters,
+		func(fs *pflag.FlagSet) {
+			fs.StringVarP(&usernames, flagUsers, flagPUsers, "", "users to leave the shift.")
+		},
+		func(fs *pflag.FlagSet, rotation *sl.Rotation, shiftNumber int) (string, error) {
+			_, deleted, err := c.SL.LeaveShift(usernames, rotation, shiftNumber)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("%s left %s", deleted.MarkdownWithSkills(), rotation.ShiftRef(shiftNumber)), nil
+		})
+}

--- a/server/solarlottery/user.go
+++ b/server/solarlottery/user.go
@@ -24,6 +24,7 @@ type Users interface {
 	Disqualify(mattermostUsernames, skillName string) error
 	JoinRotation(mattermostUsernames string, rotation *Rotation, starting time.Time) (added UserMap, err error)
 	JoinShift(mattermostUsernames string, rotation *Rotation, shiftNumber int) (*Shift, UserMap, error)
+	LeaveShift(mattermostUsernames string, rotation *Rotation, shiftNumber int) (*Shift, UserMap, error)
 	LeaveRotation(mattermostUsernames string, rotation *Rotation) (deleted UserMap, err error)
 	Qualify(mattermostUsernames, skillName string, level Level) error
 }

--- a/server/solarlottery/user_messages.go
+++ b/server/solarlottery/user_messages.go
@@ -3,9 +3,11 @@
 
 package solarlottery
 
-import "github.com/mattermost/mattermost-plugin-solar-lottery/server/config"
+import (
+	"fmt"
 
-import "fmt"
+	"github.com/mattermost/mattermost-plugin-solar-lottery/server/config"
+)
 
 func (sl *solarLottery) dmUser(user *User, message string) {
 	sl.Poster.DM(user.MattermostUserID, message)
@@ -151,6 +153,29 @@ func (sl *solarLottery) messageShiftJoined(joined UserMap, rotation *Rotation, s
 	for _, user := range joined {
 		sl.dmUser(user,
 			fmt.Sprintf("%s joined you into %s",
+				sl.actingUser.Markdown(),
+				shift.Markdown()))
+	}
+}
+
+func (sl *solarLottery) messageShiftLeft(deleted UserMap, rotation *Rotation, shift *Shift) {
+	sl.ExpandRotation(rotation)
+
+	// Notify the previous shift users that users have been deleted from the shift
+	for _, user := range rotation.ShiftUsers(shift) {
+		if deleted[user.MattermostUserID] != nil {
+			continue
+		}
+		sl.dmUser(user,
+			fmt.Sprintf("%s removed users %s from your %s",
+				sl.actingUser.Markdown(),
+				deleted.Markdown(),
+				shift.Markdown()))
+	}
+
+	for _, user := range deleted {
+		sl.dmUser(user,
+			fmt.Sprintf("%s removed you from %s.",
 				sl.actingUser.Markdown(),
 				shift.Markdown()))
 	}


### PR DESCRIPTION
**Summary**
Implements the `/lotto shift leave` command.

In this implementation the command does the same thing for **open** and **started** shift. I am certainly open to suggestions!

**Ticket**
Fixes https://github.com/mattermost/mattermost-plugin-solar-lottery/issues/14

