### PR TITLE
Add execute command endpoint

### DIFF
--- a/server/api/command.go
+++ b/server/api/command.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-solar-lottery/server/command"
+	"github.com/mattermost/mattermost-plugin-solar-lottery/server/utils/types"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin"
+)
+
+func (s *Service) executeCommand(w http.ResponseWriter, r *http.Request) {
+	userID := r.Header.Get("Mattermost-User-ID")
+	if userID == "" {
+		http.Error(w, "Not authorized", http.StatusUnauthorized)
+		return
+	}
+	args := model.CommandArgsFromJson(r.Body)
+
+	command := command.Command{
+		Context:   &plugin.Context{},
+		Args:      args,
+		ChannelID: args.ChannelId,
+		SL:        s.sl.ActingAs(types.ID(args.UserId)),
+	}
+	out, err := command.Handle()
+	if err == nil {
+		s.sl.Logger.Errorf("Error while handling command", err.Error())
+		s.handleErrorWithCode(w, http.StatusInternalServerError, "Error while handling command", err)
+	}
+
+	w.Write([]byte(out.String()))
+}

--- a/server/api/service.go
+++ b/server/api/service.go
@@ -4,9 +4,13 @@
 package api
 
 import (
+	"encoding/json"
+	"net/http"
+
 	"github.com/gorilla/mux"
 
 	"github.com/mattermost/mattermost-plugin-solar-lottery/server/config"
+	"github.com/mattermost/mattermost-plugin-solar-lottery/server/sl"
 )
 
 const (
@@ -19,14 +23,30 @@ const (
 type Service struct {
 	config config.Service
 	*mux.Router
+	sl sl.Service
 }
 
-func NewService(config config.Service, router *mux.Router) *Service {
+func NewService(config config.Service, router *mux.Router, sl sl.Service) *Service {
 	s := &Service{
 		Router: router,
 		config: config,
+		sl:     sl,
 	}
 	apiRouter := s.Router.PathPrefix(PathAPI).Subrouter()
 	apiRouter.HandleFunc("/authorized", s.apiGetAuthorized).Methods("GET")
+	apiRouter.HandleFunc("/execute_command", s.executeCommand).Methods("POST")
+
 	return s
+}
+
+func (s *Service) handleErrorWithCode(w http.ResponseWriter, code int, errTitle string, err error) {
+	w.WriteHeader(code)
+	b, _ := json.Marshal(struct {
+		Error   string `json:"error"`
+		Details string `json:"details"`
+	}{
+		Error:   errTitle,
+		Details: err.Error(),
+	})
+	_, _ = w.Write(b)
 }

--- a/server/plugin/plugin.go
+++ b/server/plugin/plugin.go
@@ -66,7 +66,7 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	router := &mux.Router{}
-	p.api = api.NewService(p.config, router)
+	p.api = api.NewService(p.config, router, p.sl)
 	router.Handle("{anything:.*}", http.NotFoundHandler())
 
 	command.Register(p.API.RegisterCommand)


### PR DESCRIPTION
#### Summary
This PR will add `execute_command` endpoint to the solar-lottery api.
#### Ticket Link
no ticket

